### PR TITLE
add an option for using the function here::here

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
+^LICENSE\.md$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,12 @@ Depends: R (>= 3.3.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
+Imports:
+    shiny (>= 0.13),
+    formatR,
+    miniUI (>= 0.1.1),
+    rstudioapi (>= 0.5),
 Suggests: 
     testthat,
     checkmate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,6 @@ Suggests:
     testthat,
     checkmate,
     knitr,
-    rmarkdown
+    rmarkdown,
+    here
 VignetteBuilder: knitr

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2018
+COPYRIGHT HOLDER: Konrad Zdeb

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2018 Konrad Zdeb
 

--- a/R/create_file_path_call.R
+++ b/R/create_file_path_call.R
@@ -8,6 +8,7 @@
 #'
 #' @param path_string Path string.
 #' @param path_sep Path separator, defults to \code{.Platform$file.sep}.
+#' @param here A logical, defaults to \code{FALSE} whether to use the function here
 #' @param normalize A logical, defaults to \code{TRUE} whether to wrap in
 #'   \code{\link[base]{normalizePath}}.
 #' @param mustWork As per \code{mustWork} in \code{\link[base]{normalizePath}}
@@ -22,6 +23,7 @@
 create_file_path_call <-
     function(path_string,
              path_sep = .Platform$file.sep,
+             here     = FALSE,
              mustWork = TRUE,
              normalize = TRUE) {
         # Break path and keep non-missing elements
@@ -30,7 +32,11 @@ create_file_path_call <-
         split_pth <- split_pth[split_pth != ""]
 
         # Construct basic file path call
-        call_file_path <- call("file.path")
+        if (here && !! requireNamespace("here", quietly = TRUE)) {
+           call_file_path <- call("here")
+        } else {
+            call_file_path <- call("file.path")
+        }
         if (!grepl("~", path_string)) {
             split_pth <- append(x = split_pth,
                                 values = "/",

--- a/R/formatPathAddIn.R
+++ b/R/formatPathAddIn.R
@@ -19,9 +19,6 @@
 formatPathAddIn <- function() {
     # Get the document context.
     context <- rstudioapi::getActiveDocumentContext()
-    # Set the default data to use based on the selection.
-    text <- context$selection[[1]]$text
-    defaultData <- text
 
     ui <- miniPage(
         gadgetTitleBar(
@@ -36,6 +33,11 @@ formatPathAddIn <- function() {
             h4("New path"),
             verbatimTextOutput("fixed_path"),
             checkboxInput(
+                inputId = "here",
+                label = "use here",
+                value = FALSE
+            ),
+            checkboxInput(
                 inputId = "normalize",
                 label = "Normalize",
                 value = FALSE
@@ -48,7 +50,6 @@ formatPathAddIn <- function() {
                     value = FALSE
                 )
             )
-
         )
     )
 
@@ -60,6 +61,14 @@ formatPathAddIn <- function() {
                               x = context[["selection"]][[1]][["text"]])
         selected_range <- context[["selection"]][[1]][["range"]]
 
+        observe({
+            if (!requireNamespace("here", quietly = TRUE) && input$here) {
+                rstudioapi::showDialog("Error",
+                                       "here is not installed",
+                                       "https://github.com/r-lib/here")
+                shiny::updateCheckboxInput(session, inputId = "here", value = FALSE)
+            }
+        })
         # Reactive document with formatted path
         reactiveDocument <- reactive({
             formatted_path <-
@@ -67,7 +76,8 @@ formatPathAddIn <- function() {
                     create_file_path_call(
                         path_string = selected_text,
                         mustWork = input$must_work,
-                        normalize = input$normalize
+                        normalize = input$normalize,
+                        here = input$here
                     )
                 )
         })

--- a/R/formatPathAddIn.R
+++ b/R/formatPathAddIn.R
@@ -1,4 +1,4 @@
-#' @title Format File Path
+#' @title Ffile.path("/")ormat File Path
 #'
 #' @description The functions provides an add-in interface on the
 #'   \code{\link{create_file_path_call}} function.
@@ -17,8 +17,6 @@
 #' @export
 #'
 formatPathAddIn <- function() {
-    # Get the document context.
-    context <- rstudioapi::getActiveDocumentContext()
 
     ui <- miniPage(
         gadgetTitleBar(
@@ -59,6 +57,12 @@ formatPathAddIn <- function() {
         selected_text <- gsub(pattern = '"',
                               replacement = '',
                               x = context[["selection"]][[1]][["text"]])
+        # if nothing is selected, warns the user and exit
+        if (!nzchar(selected_text)) {
+            rstudioapi::showDialog("Error",
+                                   "text selection is empty")
+            invisible(stopApp())
+        }
         selected_range <- context[["selection"]][[1]][["range"]]
 
         observe({

--- a/man/create_file_path_call.Rd
+++ b/man/create_file_path_call.Rd
@@ -5,12 +5,14 @@
 \title{Create File Path Call}
 \usage{
 create_file_path_call(path_string, path_sep = .Platform$file.sep,
-  mustWork = TRUE, normalize = TRUE)
+  here = FALSE, mustWork = TRUE, normalize = TRUE)
 }
 \arguments{
 \item{path_string}{Path string.}
 
 \item{path_sep}{Path separator, defults to \code{.Platform$file.sep}.}
+
+\item{here}{A logical, defaults to \code{FALSE} whether to use the function here}
 
 \item{mustWork}{As per \code{mustWork} in \code{\link[base]{normalizePath}}}
 

--- a/tests/testthat/test_creating_file_path_call.R
+++ b/tests/testthat/test_creating_file_path_call.R
@@ -11,3 +11,27 @@ if (requireNamespace("checkmate", quietly = TRUE)) {
               code = checkmate::expect_string(eval(create_file_path_call(tempdir(
               )))))
 }
+
+test_that("returned strings", {
+    sep <- .Platform$file.sep
+    path <- paste0("test", sep, "this")
+    expect_equal(deparse(create_file_path_call(path)),
+                 "normalizePath(file.path(\"/\", \"test\", \"this\"), mustWork = TRUE)")
+    expect_equal(deparse(create_file_path_call(path, normalize = FALSE)),
+                 "file.path(\"/\", \"test\", \"this\")")
+    expect_equal(deparse(create_file_path_call(path, mustWork = FALSE)),
+                 "normalizePath(file.path(\"/\", \"test\", \"this\"))")
+    if (requireNamespace("here", quietly = TRUE)) {
+        expect_equal(deparse(create_file_path_call(path, here = TRUE, normalize = FALSE)),
+                     "here(\"/\", \"test\", \"this\")")
+    }
+})
+
+test_that("useable path", {
+    dcf <- system.file("rstudio", "addins.dcf",
+                       package = "reformatFilePath", mustWork = TRUE)
+    content <- readLines(eval(create_file_path_call(dcf)))
+    expect_equal(content, c("Name: Format File Path",
+                            "Description: Format file path using 'file.path()'",
+                            "Binding: formatPathAddIn", "Interactive: true"))
+})


### PR DESCRIPTION
For fixing #1 

- an option for here, checking if the package `here` if installed.

I have one doubt though, you prefix all paths with a leading **/** except if you see a **~**.
But, I don't get why, if we want a relative path, why should you add a leading slash?

To me `"practicals/data/mtcars,csv"`  should return `file.path("practicals", "data", "mtcars,csv")`
and not file.path("/", "practicals", "data", "mtcars,csv").

I haven't change your function as I may be wrong here.

Of note:

- I cleaned up the code, removing unused variables and fixing the issues raised by `rcmdcheck`
- add a LICENSE using `usethis` to fix a warning
- add necessary packages in `Imports` for the addin
- added some tests